### PR TITLE
TellTarget: Fix a bug preventing /tt working for far away players of the same server

### DIFF
--- a/telltarget.lua
+++ b/telltarget.lua
@@ -8,7 +8,7 @@ BCM.modules[#BCM.modules+1] = function()
 	SlashCmdList["TELLTARGET"] = function(msg)
 		if UnitIsPlayer("target") and UnitIsFriend("player", "target") and msg and msg:len() > 0 then
 			local name, realm = UnitName("target")
-			if realm then
+                if realm and realm ~= "" then
 				name = name.."-"..realm
 			end
 			SendChatMessage(msg, "WHISPER", nil, name)

--- a/telltarget.lua
+++ b/telltarget.lua
@@ -8,7 +8,7 @@ BCM.modules[#BCM.modules+1] = function()
 	SlashCmdList["TELLTARGET"] = function(msg)
 		if UnitIsPlayer("target") and UnitIsFriend("player", "target") and msg and msg:len() > 0 then
 			local name, realm = UnitName("target")
-                if realm and realm ~= "" then
+			if realm and realm ~= "" then
 				name = name.."-"..realm
 			end
 			SendChatMessage(msg, "WHISPER", nil, name)


### PR DESCRIPTION
Telltarget `/tt` can in some cases whispers to `playername-`. That is `UnitName` can return empty string as the realm portion. This PR explicitly tests against empty string fixing this issue.